### PR TITLE
OpenJDK, update Dockstore and deps

### DIFF
--- a/env/platform.env
+++ b/env/platform.env
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export OS_BASE_FLAVOR="o1.small"
+export OS_BASE_FLAVOR="o2.small"
 export OS_FIP_POOL="public"

--- a/env/ubuntu/build.env
+++ b/env/ubuntu/build.env
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # use UUID of image from your OpenStack deployment
-export OS_BASE_IMAGE="Bionic"
+export OS_BASE_IMAGE="bionic-server"
 export DOCKER_VERSION="18.06.1~ce~3-0~ubuntu"

--- a/env/versions.env
+++ b/env/versions.env
@@ -5,14 +5,14 @@
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # See bottom of dockstore.org page for API version
-export DOCKSTORE_VERSION="1.5.1"
+export DOCKSTORE_VERSION="1.6.0"
 export DOCKSTORE_S3CMD_VER="0.0.8"
 # https://dockstore.org/onboarding
 # Use this curl to get full requirements file:
-# curl -o requirements_py2.txt "https://dockstore.org:443/api/metadata/runner_dependencies?client_version=1.5.1&python_version=2"
-export PIP_SETUPTOOLS_VER="36.5.0"
-export PIP_CWLTOOL_VER="1.0.20180403145700"
-export PIP_SCHEMA_SALAD_VER="2.7.20180514132321"
-export PIP_AVRO_VER="1.8.1"
-export PIP_RUAMEL="0.14.12"
-export PIP_REQUESTS="2.18.4"
+# curl -o requirements_py2.txt "https://dockstore.org:443/api/metadata/runner_dependencies?client_version=1.6.0&python_version=2"
+export PIP_SETUPTOOLS_VER="40.8.0"
+export PIP_CWLTOOL_VER="1.0.20181217162649"
+export PIP_SCHEMA_SALAD_VER="3.0.20181206233650"
+export PIP_AVRO_VER="1.8.2"
+export PIP_RUAMEL="0.15.77"
+export PIP_REQUESTS="2.21.0"

--- a/scripts/pbuild.sh
+++ b/scripts/pbuild.sh
@@ -5,7 +5,7 @@ CGP_DS_VERSION=2.2.0
 set -ue
 
 if [ $# -ne 4 ]; then
-  echo "Execute as: pbuild.sh <ubuntu|alpine> <NETWORK_NAME> <SECURITY_GROUP> <XXX-openrc-v2.sh>"
+  echo "Execute as: pbuild.sh <ubuntu|alpine> <NETWORK_NAME> <SECURITY_GROUP> <XXX-openrc.sh>"
   exit 1
 fi
 

--- a/scripts/ubuntu/build.sh
+++ b/scripts/ubuntu/build.sh
@@ -23,4 +23,4 @@ sudo apt-get -yq update
 sudo apt-get -yq install --no-install-recommends openjdk-8-jre-headless
 
 # useful tools and python deps
-sudo apt-get -yq install --no-install-recommends nano less python-dev python-pip
+sudo apt-get -yq install --no-install-recommends build-essential nano less python-dev python-pip

--- a/scripts/ubuntu/build.sh
+++ b/scripts/ubuntu/build.sh
@@ -20,7 +20,7 @@ sudo add-apt-repository -y ppa:openjdk-r/ppa
 #sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections'
 #sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections'
 sudo apt-get -yq update
-sudo apt-get -yq install --no-install-recommends openjdk-8-jdk
+sudo apt-get -yq install --no-install-recommends openjdk-8-jre-headless
 
 # useful tools and python deps
 sudo apt-get -yq install --no-install-recommends nano less python-dev python-pip

--- a/scripts/ubuntu/build.sh
+++ b/scripts/ubuntu/build.sh
@@ -17,8 +17,6 @@ sudo usermod -aG docker ubuntu
 
 ## JAVA for DOCKSTORE - no jre8 in apt by default
 sudo add-apt-repository -y ppa:openjdk-r/ppa
-#sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections'
-#sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections'
 sudo apt-get -yq update
 sudo apt-get -yq install --no-install-recommends openjdk-8-jre-headless
 

--- a/scripts/ubuntu/build.sh
+++ b/scripts/ubuntu/build.sh
@@ -16,11 +16,11 @@ sudo apt-get -y install docker-ce=$DOCKER_VERSION
 sudo usermod -aG docker ubuntu
 
 ## JAVA for DOCKSTORE - no jre8 in apt by default
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections'
-sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections'
+sudo add-apt-repository -y ppa:openjdk-r/ppa
+#sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections'
+#sudo bash -c '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections'
 sudo apt-get -yq update
-sudo apt-get -yq install --no-install-recommends oracle-java8-installer
+sudo apt-get -yq install --no-install-recommends openjdk-8-jdk
 
 # useful tools and python deps
 sudo apt-get -yq install --no-install-recommends nano less python-dev python-pip


### PR DESCRIPTION
* Migrated to openJdk
* Dockstore 1.6.0
  * and related cwltool deps
* Minor update to some defaults to allow out-of-box use within Sanger (Eta/Queens)